### PR TITLE
Add overflow attribute to <pre> tags

### DIFF
--- a/blog/style.css
+++ b/blog/style.css
@@ -77,4 +77,5 @@ pre {
   background: #def;
   font-weight: bold;
   font-size: 0.8em;
+  overflow: auto
 }


### PR DESCRIPTION
Hi,

thank you for the great article on Dino Rush!

I added the overflow attribute to `<pre>` tags, so it's possible to scroll sideways if the code line is wider than its surrounding `<pre>` box.